### PR TITLE
Project: changed key type of cache used for renaming file path within a template

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ extern crate rig;
 
 use std::collections::HashMap;
 use std::env;
-use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::exit;
@@ -26,8 +25,7 @@ use url::Url;
 
 use rig::errors::*;
 use rig::format::{format, Format};
-use rig::fsutils;
-use rig::project::{ConfigFormat, Project};
+use rig::project::Project;
 
 const USAGE: &'static str = r#"
 Rig - Generate new project by cloning templates from git repository.


### PR DESCRIPTION
From String to OsString, to reduce the number of conversions.